### PR TITLE
Add txn/call hints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4.19"
 num-bigint = "0.4"
 num-integer = "0.1.45"
 num-traits = "0.2.16"
+num-bigint = "0.4"
 regex = "1.10.0"
 reqwest = { version = "0.11.18", features = ["blocking", "json"] }
 serde = { version = "1.0.188", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ log = "0.4.19"
 num-bigint = "0.4"
 num-integer = "0.1.45"
 num-traits = "0.2.16"
-num-bigint = "0.4"
 regex = "1.10.0"
 reqwest = { version = "0.11.18", features = ["blocking", "json"] }
 serde = { version = "1.0.188", features = ["derive"] }

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -412,7 +412,6 @@ pub fn is_on_curve(
     Ok(())
 }
 
-#[allow(unused)]
 const START_TX: &str = "execution_helper.start_tx(tx_info_ptr=ids.deprecated_tx_info.address_)";
 
 pub fn start_tx(
@@ -422,7 +421,8 @@ pub fn start_tx(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let deprecated_tx_info_ptr = get_relocatable_from_var_name("deprecated_tx_info", vm, ids_data, ap_tracking)?;
+    let deprecated_tx_info_ptr =
+        get_relocatable_from_var_name(vars::ids::DEPRECATED_TX_INFO, vm, ids_data, ap_tracking)?;
 
     let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper").unwrap();
     execution_helper.start_tx(Some(deprecated_tx_info_ptr));

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -433,10 +433,10 @@ pub fn start_tx(
 
 const SKIP_TX: &str = "execution_helper.skip_tx()";
 pub fn skip_tx(
-    vm: &mut VirtualMachine,
+    _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
-    ids_data: &HashMap<String, HintReference>,
-    ap_tracking: &ApTracking,
+    _ids_data: &HashMap<String, HintReference>,
+    _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER).unwrap();

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -425,8 +425,7 @@ pub fn start_tx(
     let deprecated_tx_info_ptr =
         get_relocatable_from_var_name(vars::ids::DEPRECATED_TX_INFO, vm, ids_data, ap_tracking)?;
 
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER)
-        .unwrap();
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER).unwrap();
     execution_helper.start_tx(Some(deprecated_tx_info_ptr));
 
     Ok(())
@@ -440,10 +439,8 @@ pub fn skip_tx(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER)
-        .unwrap();
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER).unwrap();
     execution_helper.skip_tx();
-    
+
     Ok(())
 }
-

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -38,7 +38,7 @@ type HintImpl = fn(
     &HashMap<String, Felt252>,
 ) -> Result<(), HintError>;
 
-static HINTS: [(&str, HintImpl); 52] = [
+static HINTS: [(&str, HintImpl); 53] = [
     // (BREAKPOINT, breakpoint),
     (STARKNET_OS_INPUT, starknet_os_input),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -93,6 +93,7 @@ static HINTS: [(&str, HintImpl); 52] = [
     (SET_AP_TO_ACTUAL_FEE, set_ap_to_actual_fee),
     (IS_ON_CURVE, is_on_curve),
     (IS_N_GE_TWO, is_n_ge_two),
+    (START_TX, start_tx),
 ];
 
 /// Hint Extensions extend the current map of hints used by the VM.

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -7,9 +7,6 @@ mod tests;
 mod unimplemented;
 mod vars;
 
-#[cfg(test)]
-mod tests;
-
 use std::collections::{HashMap, HashSet};
 
 use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
@@ -412,24 +409,4 @@ pub fn is_on_curve(
     insert_value_from_var_name(vars::ids::IS_ON_CURVE, is_on_curve, vm, ids_data, ap_tracking)?;
 
     Ok(())
-}
-
-const SET_AP_TO_ACTUAL_FEE: &str = "memory[ap] = to_felt_or_relocatable(execution_helper.tx_execution_info.actual_fee)";
-pub fn set_ap_to_actual_fee(
-    vm: &mut VirtualMachine,
-    exec_scopes: &mut ExecutionScopes,
-    ids_data: &HashMap<String, HintReference>,
-    ap_tracking: &ApTracking,
-    constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
-    let execution_helper = exec_scopes .get::<ExecutionHelperWrapper>("execution_helper")?;
-    let actual_fee = execution_helper
-        .execution_helper
-        .borrow()
-        .tx_execution_info
-        .as_ref()
-        .expect("ExecutionHelper should have tx_execution_info")
-        .actual_fee;
-
-    insert_value_into_ap(vm, Felt252::from(actual_fee.0))
 }

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -38,7 +38,7 @@ type HintImpl = fn(
     &HashMap<String, Felt252>,
 ) -> Result<(), HintError>;
 
-static HINTS: [(&str, HintImpl); 54] = [
+static HINTS: [(&str, HintImpl); 55] = [
     // (BREAKPOINT, breakpoint),
     (STARKNET_OS_INPUT, starknet_os_input),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -95,6 +95,7 @@ static HINTS: [(&str, HintImpl); 54] = [
     (IS_N_GE_TWO, is_n_ge_two),
     (START_TX, start_tx),
     (SKIP_TX, skip_tx),
+    (SKIP_CALL, skip_call),
 ];
 
 /// Hint Extensions extend the current map of hints used by the VM.
@@ -441,6 +442,20 @@ pub fn skip_tx(
 ) -> Result<(), HintError> {
     let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER).unwrap();
     execution_helper.skip_tx();
+
+    Ok(())
+}
+
+const SKIP_CALL: &str = "execution_helper.skip_call()";
+pub fn skip_call(
+    _vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    _ids_data: &HashMap<String, HintReference>,
+    _ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER).unwrap();
+    execution_helper.skip_call();
 
     Ok(())
 }

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -410,3 +410,21 @@ pub fn is_on_curve(
 
     Ok(())
 }
+
+#[allow(unused)]
+const START_TX: &str = "execution_helper.start_tx(tx_info_ptr=ids.deprecated_tx_info.address_)";
+
+pub fn start_tx(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let deprecated_tx_info_ptr = get_relocatable_from_var_name("deprecated_tx_info", vm, ids_data, ap_tracking)?;
+
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper").unwrap();
+    execution_helper.start_tx(Some(deprecated_tx_info_ptr));
+
+    Ok(())
+}

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -7,6 +7,9 @@ mod tests;
 mod unimplemented;
 mod vars;
 
+#[cfg(test)]
+mod tests;
+
 use std::collections::{HashMap, HashSet};
 
 use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
@@ -409,4 +412,24 @@ pub fn is_on_curve(
     insert_value_from_var_name(vars::ids::IS_ON_CURVE, is_on_curve, vm, ids_data, ap_tracking)?;
 
     Ok(())
+}
+
+const SET_AP_TO_ACTUAL_FEE: &str = "memory[ap] = to_felt_or_relocatable(execution_helper.tx_execution_info.actual_fee)";
+pub fn set_ap_to_actual_fee(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let execution_helper = exec_scopes .get::<ExecutionHelperWrapper>("execution_helper")?;
+    let actual_fee = execution_helper
+        .execution_helper
+        .borrow()
+        .tx_execution_info
+        .as_ref()
+        .expect("ExecutionHelper should have tx_execution_info")
+        .actual_fee;
+
+    insert_value_into_ap(vm, Felt252::from(actual_fee.0))
 }

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -426,13 +426,14 @@ pub fn start_tx(
     let deprecated_tx_info_ptr =
         get_relocatable_from_var_name(vars::ids::DEPRECATED_TX_INFO, vm, ids_data, ap_tracking)?;
 
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER).unwrap();
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER).unwrap();
     execution_helper.start_tx(Some(deprecated_tx_info_ptr));
 
     Ok(())
 }
 
 const SKIP_TX: &str = "execution_helper.skip_tx()";
+
 pub fn skip_tx(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -440,13 +441,14 @@ pub fn skip_tx(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER).unwrap();
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER).unwrap();
     execution_helper.skip_tx();
 
     Ok(())
 }
 
 const SKIP_CALL: &str = "execution_helper.skip_call()";
+
 pub fn skip_call(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -454,7 +456,7 @@ pub fn skip_call(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER).unwrap();
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER).unwrap();
     execution_helper.skip_call();
 
     Ok(())

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -38,7 +38,7 @@ type HintImpl = fn(
     &HashMap<String, Felt252>,
 ) -> Result<(), HintError>;
 
-static HINTS: [(&str, HintImpl); 53] = [
+static HINTS: [(&str, HintImpl); 54] = [
     // (BREAKPOINT, breakpoint),
     (STARKNET_OS_INPUT, starknet_os_input),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -94,6 +94,7 @@ static HINTS: [(&str, HintImpl); 53] = [
     (IS_ON_CURVE, is_on_curve),
     (IS_N_GE_TWO, is_n_ge_two),
     (START_TX, start_tx),
+    (SKIP_TX, skip_tx),
 ];
 
 /// Hint Extensions extend the current map of hints used by the VM.
@@ -424,8 +425,25 @@ pub fn start_tx(
     let deprecated_tx_info_ptr =
         get_relocatable_from_var_name(vars::ids::DEPRECATED_TX_INFO, vm, ids_data, ap_tracking)?;
 
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper").unwrap();
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER)
+        .unwrap();
     execution_helper.start_tx(Some(deprecated_tx_info_ptr));
 
     Ok(())
 }
+
+const SKIP_TX: &str = "execution_helper.skip_tx()";
+pub fn skip_tx(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::ids::EXECUTION_HELPER)
+        .unwrap();
+    execution_helper.skip_tx();
+    
+    Ok(())
+}
+

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -3,7 +3,6 @@ pub(crate) mod tests {
     use std::sync::Arc;
 
     use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};
-    use blockifier::transaction::errors::TransactionExecutionError;
     use blockifier::transaction::objects::TransactionExecutionInfo;
     use cairo_vm::serde::deserialize_program::ApTracking;
     use cairo_vm::types::exec_scope::ExecutionScopes;
@@ -177,7 +176,7 @@ pub(crate) mod tests {
         let execution_infos = vec![transaction_execution_info];
         let exec_helper = ExecutionHelperWrapper::new(execution_infos, &block_context);
         let exec_helper_box = Box::new(exec_helper);
-        exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, exec_helper_box.clone());
+        exec_scopes.insert_box(vars::scopes::EXECUTION_HELPER, exec_helper_box.clone());
 
         // before starting tx, tx_execution_info should be none
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_none());
@@ -205,7 +204,7 @@ pub(crate) mod tests {
         let execution_infos = vec![transaction_execution_info];
         let exec_helper = ExecutionHelperWrapper::new(execution_infos, &block_context);
         let exec_helper_box = Box::new(exec_helper);
-        exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, exec_helper_box.clone());
+        exec_scopes.insert_box(vars::scopes::EXECUTION_HELPER, exec_helper_box.clone());
 
         // before skipping a tx, tx_execution_info should be none and iter should have a next()
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_none());
@@ -237,7 +236,7 @@ pub(crate) mod tests {
         let execution_infos = vec![transaction_execution_info];
         let exec_helper = ExecutionHelperWrapper::new(execution_infos, &block_context);
         let exec_helper_box = Box::new(exec_helper);
-        exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, exec_helper_box.clone());
+        exec_scopes.insert_box(vars::scopes::EXECUTION_HELPER, exec_helper_box.clone());
 
         start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("start_tx");
 

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -3,7 +3,11 @@ pub(crate) mod tests {
     use std::sync::Arc;
 
     use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};
+    use blockifier::transaction::errors::TransactionExecutionError;
     use blockifier::transaction::objects::TransactionExecutionInfo;
+    use cairo_vm::serde::deserialize_program::ApTracking;
+    use cairo_vm::types::exec_scope::ExecutionScopes;
+    use num_bigint::BigInt;
     use rstest::{fixture, rstest};
     use starknet_api::block::{BlockNumber, BlockTimestamp};
     use starknet_api::core::{ChainId, ContractAddress, PatriciaKey};

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -160,4 +160,29 @@ pub(crate) mod tests {
         let result = vm.get_integer(relocatable).unwrap().into_owned();
         assert_eq!(result, expected);
     }
+
+    #[rstest]
+    fn test_start_tx(
+        block_context: BlockContext,
+        transaction_execution_info: TransactionExecutionInfo,
+    ) {
+        let mut vm = VirtualMachine::new(false);
+        vm.set_fp(1);
+        vm.add_memory_segment();
+        vm.add_memory_segment();
+
+        let ids_data = ids_data![vars::ids::IS_ON_CURVE];
+        let ap_tracking = ApTracking::default();
+
+        let mut exec_scopes = ExecutionScopes::new();
+
+        // we need an execution info in order to start a tx
+        let execution_infos = vec![transaction_execution_info];
+        let exec_helper = ExecutionHelperWrapper::new(execution_infos, &block_context);
+        exec_helper.start_tx(None);
+        exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, Box::new(exec_helper));
+
+        start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
+            .expect("start_tx");
+    }
 }

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -162,10 +162,7 @@ pub(crate) mod tests {
     }
 
     #[rstest]
-    fn test_start_tx(
-        block_context: BlockContext,
-        transaction_execution_info: TransactionExecutionInfo,
-    ) {
+    fn test_start_tx(block_context: BlockContext, transaction_execution_info: TransactionExecutionInfo) {
         let mut vm = VirtualMachine::new(false);
         vm.set_fp(1);
         vm.add_memory_segment();
@@ -185,18 +182,14 @@ pub(crate) mod tests {
         // before starting tx, tx_execution_info should be none
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_none());
 
-        start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
-            .expect("start_tx");
+        start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("start_tx");
 
         // after starting tx, tx_execution_info should be some
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_some());
     }
 
     #[rstest]
-    fn test_skip_tx(
-        block_context: BlockContext,
-        transaction_execution_info: TransactionExecutionInfo,
-    ) {
+    fn test_skip_tx(block_context: BlockContext, transaction_execution_info: TransactionExecutionInfo) {
         let mut vm = VirtualMachine::new(false);
         vm.set_fp(1);
         vm.add_memory_segment();
@@ -218,12 +211,10 @@ pub(crate) mod tests {
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_none());
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info_iter.clone().peekable().peek().is_some());
 
-        start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
-            .expect("start_tx");
+        start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("start_tx");
 
         // after starting tx, tx_execution_info should be some and iter should not have a next()
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_some());
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info_iter.clone().peekable().peek().is_none());
     }
 }
-

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -171,7 +171,7 @@ pub(crate) mod tests {
         vm.add_memory_segment();
         vm.add_memory_segment();
 
-        let ids_data = ids_data![vars::ids::IS_ON_CURVE];
+        let ids_data = ids_data![vars::ids::DEPRECATED_TX_INFO];
         let ap_tracking = ApTracking::default();
 
         let mut exec_scopes = ExecutionScopes::new();
@@ -179,10 +179,12 @@ pub(crate) mod tests {
         // we need an execution info in order to start a tx
         let execution_infos = vec![transaction_execution_info];
         let exec_helper = ExecutionHelperWrapper::new(execution_infos, &block_context);
-        exec_helper.start_tx(None);
-        exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, Box::new(exec_helper));
+        let exec_helper_box = Box::new(exec_helper);
+        exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, exec_helper_box.clone());
 
         start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
             .expect("start_tx");
+
+        assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_some());
     }
 }

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -207,14 +207,14 @@ pub(crate) mod tests {
         let exec_helper_box = Box::new(exec_helper);
         exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, exec_helper_box.clone());
 
-        // before starting tx, tx_execution_info should be none and iter should have a next()
+        // before skipping a tx, tx_execution_info should be none and iter should have a next()
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_none());
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info_iter.clone().peekable().peek().is_some());
 
-        start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("start_tx");
+        skip_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("start_tx");
 
-        // after starting tx, tx_execution_info should be some and iter should not have a next()
-        assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_some());
+        // after skipping a tx, tx_execution_info should be some and iter should not have a next()
+        assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_none());
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info_iter.clone().peekable().peek().is_none());
     }
 }

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -191,4 +191,39 @@ pub(crate) mod tests {
         // after starting tx, tx_execution_info should be some
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_some());
     }
+
+    #[rstest]
+    fn test_skip_tx(
+        block_context: BlockContext,
+        transaction_execution_info: TransactionExecutionInfo,
+    ) {
+        let mut vm = VirtualMachine::new(false);
+        vm.set_fp(1);
+        vm.add_memory_segment();
+        vm.add_memory_segment();
+
+        let ids_data = ids_data![vars::ids::DEPRECATED_TX_INFO];
+        let ap_tracking = ApTracking::default();
+
+        let mut exec_scopes = ExecutionScopes::new();
+
+        // skipping a tx is the same as starting and immediately ending it, so we need one
+        // execution info to chew through
+        let execution_infos = vec![transaction_execution_info];
+        let exec_helper = ExecutionHelperWrapper::new(execution_infos, &block_context);
+        let exec_helper_box = Box::new(exec_helper);
+        exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, exec_helper_box.clone());
+
+        // before starting tx, tx_execution_info should be none and iter should have a next()
+        assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_none());
+        assert!(exec_helper_box.execution_helper.borrow().tx_execution_info_iter.clone().peekable().peek().is_some());
+
+        start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
+            .expect("start_tx");
+
+        // after starting tx, tx_execution_info should be some and iter should not have a next()
+        assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_some());
+        assert!(exec_helper_box.execution_helper.borrow().tx_execution_info_iter.clone().peekable().peek().is_none());
+    }
 }
+

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -8,7 +8,7 @@ pub(crate) mod tests {
     use cairo_vm::serde::deserialize_program::ApTracking;
     use cairo_vm::types::exec_scope::ExecutionScopes;
     use num_bigint::BigInt;
-    use rstest::{fixture, rstest, rstest};
+    use rstest::{fixture, rstest};
     use starknet_api::block::{BlockNumber, BlockTimestamp};
     use starknet_api::core::{ChainId, ContractAddress, PatriciaKey};
     use starknet_api::hash::StarkHash;

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -240,8 +240,13 @@ pub(crate) mod tests {
         exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, exec_helper_box.clone());
 
         start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("start_tx");
+
+        // we should have a call next
+        assert!(exec_helper_box.execution_helper.borrow().call_iter.clone().peekable().peek().is_some());
+
         skip_call(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("skip_call");
 
-        // TODO: inspect calls iter (or similar)
+        // our only call should have been consumed
+        assert!(exec_helper_box.execution_helper.borrow().call_iter.clone().peekable().peek().is_none());
     }
 }

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -8,7 +8,7 @@ pub(crate) mod tests {
     use cairo_vm::serde::deserialize_program::ApTracking;
     use cairo_vm::types::exec_scope::ExecutionScopes;
     use num_bigint::BigInt;
-    use rstest::{fixture, rstest};
+    use rstest::{fixture, rstest, rstest};
     use starknet_api::block::{BlockNumber, BlockTimestamp};
     use starknet_api::core::{ChainId, ContractAddress, PatriciaKey};
     use starknet_api::hash::StarkHash;

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -182,9 +182,13 @@ pub(crate) mod tests {
         let exec_helper_box = Box::new(exec_helper);
         exec_scopes.insert_box(vars::ids::EXECUTION_HELPER, exec_helper_box.clone());
 
+        // before starting tx, tx_execution_info should be none
+        assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_none());
+
         start_tx(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
             .expect("start_tx");
 
+        // after starting tx, tx_execution_info should be some
         assert!(exec_helper_box.execution_helper.borrow().tx_execution_info.is_some());
     }
 }

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -238,9 +238,6 @@ const ENTER_SCOPE_NEXT_NODE_2: &str = indoc! {r#"
 };
 
 #[allow(unused)]
-const START_TX: &str = "execution_helper.start_tx(tx_info_ptr=ids.deprecated_tx_info.address_)";
-
-#[allow(unused)]
 const WRITE_OLD_BLOCK_TO_STORAGE: &str = indoc! {r#"
 	storage = execution_helper.storage_by_address[ids.BLOCK_HASH_CONTRACT_ADDRESS]
 	storage.write(key=ids.old_block_number, value=ids.old_block_hash)"#

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -225,9 +225,6 @@ const SET_TX_INFO_PTR: &str = indoc! {r#"
 const SPLIT_INPUTS_12: &str = "ids.high12, ids.low12 = divmod(memory[ids.inputs + 12], 256 ** 4)";
 
 #[allow(unused)]
-const SKIP_TX: &str = "execution_helper.skip_tx()";
-
-#[allow(unused)]
 const SET_AP_TO_IS_REVERTED: &str =
     "memory[ap] = to_felt_or_relocatable(execution_helper.tx_execution_info.is_reverted)";
 

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -175,9 +175,6 @@ const CACHE_CONTRACT_STORAGE_2: &str = indoc! {r#"
 };
 
 #[allow(unused)]
-const SKIP_CALL: &str = "execution_helper.skip_call()";
-
-#[allow(unused)]
 const SET_BIT: &str = "ids.bit = (ids.edge.path >> ids.new_length) & 1";
 
 #[allow(unused)]

--- a/src/hints/vars.rs
+++ b/src/hints/vars.rs
@@ -11,4 +11,5 @@ pub mod ids {
     pub const Y: &str = "y";
     pub const Y_SQUARE_INT: &str = "y_square_int";
     pub const N: &str = "n";
+    pub const DEPRECATED_TX_INFO: &str = "deprecated_tx_info";
 }


### PR DESCRIPTION
Adds several hints related to txns and calls.

Currently uses as a starting point `notlesh/set_ap_to_actual_fee_hint` (e.g. #2), I will clean that up when it is merged.