### PR TITLE
Feature: read/write Cairo structs safely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-type-derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "cairo-vm"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3114,6 +3122,7 @@ dependencies = [
  "base64",
  "bitvec",
  "blockifier",
+ "cairo-type-derive",
  "cairo-vm 1.0.0-rc0",
  "hex",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+workspace = { members = ["cairo-type-derive"] }
 [package]
 edition = "2021"
 name = "snos"
@@ -8,6 +9,7 @@ anyhow = "1.0.75"
 base64 = "0.21.3"
 bitvec = { version = "1.0.1", features = ["serde"] }
 blockifier = { git = "https://github.com/keep-starknet-strange/blockifier", branch = "snos/callinfo-clone", features = ["clone", "testing"] }
+cairo-type-derive = { version = "0.1.0", path = "cairo-type-derive" }
 cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", features = ["extensive_hints"] }
 hex = "0.4.3"
 indexmap = "1.9.2"

--- a/cairo-type-derive/Cargo.toml
+++ b/cairo-type-derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cairo-type-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.35"
+syn = "2.0.48"

--- a/cairo-type-derive/src/lib.rs
+++ b/cairo-type-derive/src/lib.rs
@@ -1,0 +1,118 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
+
+#[proc_macro_derive(CairoType)]
+pub fn cairo_type_derive(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Get the identifier of the struct
+    let struct_ident = &input.ident;
+
+    // Generate code to implement the trait
+    let expanded = match &input.data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(fields) => {
+                let field_names_read = fields.named.iter().map(|f| &f.ident);
+                let field_names_write = field_names_read.clone();
+                let n_fields = field_names_read.clone().count();
+                let field_values = field_names_read.clone().enumerate().map(|(index, field_name)| {
+                    quote! {
+                        let #field_name = vm.get_integer(&address + #index)?.into_owned();
+                    }
+                });
+
+                quote! {
+                    impl CairoType for #struct_ident {
+                        fn from_memory(vm: &VirtualMachine, address: Relocatable) -> Result<Self, MemoryError> {
+                         #(#field_values)*
+                            Ok(Self {
+                                #( #field_names_read ),*
+                            })
+                        }
+                        fn to_memory(&self, vm: &mut VirtualMachine, address: Relocatable) -> Result<(), MemoryError> {
+                            let mut offset = 0;
+                            #(vm.insert_value(&address + offset, &self.#field_names_write)?; offset += 1;)*
+
+                            Ok(())
+                        }
+
+                        fn n_fields() -> usize {
+                            #n_fields
+                        }
+                    }
+                }
+            }
+            Fields::Unnamed(_) | Fields::Unit => {
+                // Unsupported field types
+                quote! {
+                    compile_error!("CairoType only supports structs with named fields");
+                }
+            }
+        },
+        Data::Enum(_) | Data::Union(_) => {
+            // Unsupported data types
+            quote! {
+                compile_error!("CairoType only supports structs");
+            }
+        }
+    };
+
+    // Convert the generated code into a TokenStream and return it
+    TokenStream::from(expanded)
+}
+
+/// Provides a method to compute the address of each field
+#[proc_macro_derive(FieldOffsetGetters)]
+pub fn get_field_addr_derive(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Get the identifier of the struct
+    let struct_ident = &input.ident;
+
+    // Generate code to implement the trait
+    let getters = match &input.data {
+        Data::Struct(data_struct) => {
+            // Extract fields' names and types
+            let fields = match &data_struct.fields {
+                Fields::Named(fields) => &fields.named,
+                _ => {
+                    return quote! {
+                        compile_error!("FieldOffsetGetters only supports structs with named fields");
+                    }
+                    .into();
+                }
+            };
+
+            // Generate setter methods for each field
+            let get_field_offset_methods = fields.iter().enumerate().map(|(index, field)| {
+                let field_name = field.ident.as_ref().expect("Expected named field");
+                let fn_name = format_ident!("{}_offset", field_name);
+                quote! {
+                    pub fn #fn_name() -> usize {
+                        #index
+                    }
+                }
+            });
+
+            // Combine all setter methods
+            quote! {
+                impl #struct_ident {
+                    #( #get_field_offset_methods )*
+                }
+            }
+        }
+        _ => {
+            quote! {
+                compile_error!("FieldOffsetGetters only supports structs");
+            }
+        }
+    };
+
+    // Convert the generated code into a TokenStream and return it
+    getters.into()
+}

--- a/src/cairo_types/builtins.rs
+++ b/src/cairo_types/builtins.rs
@@ -1,0 +1,20 @@
+use cairo_type_derive::FieldOffsetGetters;
+use cairo_vm::Felt252;
+
+#[allow(unused)]
+#[derive(FieldOffsetGetters)]
+pub struct HashBuiltin {
+    pub x: Felt252,
+    pub y: Felt252,
+    pub result: Felt252,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct SpongeHashBuiltin {
+    pub x: Felt252,
+    pub y: Felt252,
+    pub c_in: Felt252,
+    pub result: Felt252,
+    pub result1: Felt252,
+    pub c_out: Felt252,
+}

--- a/src/cairo_types/mod.rs
+++ b/src/cairo_types/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod builtins;
+pub(crate) mod traits;
+pub(crate) mod trie;

--- a/src/cairo_types/traits.rs
+++ b/src/cairo_types/traits.rs
@@ -1,0 +1,75 @@
+use cairo_vm::types::relocatable::Relocatable;
+use cairo_vm::vm::errors::memory_errors::MemoryError;
+use cairo_vm::vm::vm_core::VirtualMachine;
+
+pub trait CairoType: Sized {
+    fn from_memory(vm: &VirtualMachine, address: Relocatable) -> Result<Self, MemoryError>;
+    fn to_memory(&self, vm: &mut VirtualMachine, address: Relocatable) -> Result<(), MemoryError>;
+
+    fn n_fields() -> usize;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use cairo_type_derive::{CairoType, FieldOffsetGetters};
+    use cairo_vm::Felt252;
+
+    use super::*;
+
+    #[derive(CairoType, FieldOffsetGetters)]
+    struct MyType {
+        pub a: Felt252,
+        pub b: Felt252,
+        pub c: Felt252,
+    }
+
+    #[test]
+    fn write_cairo_type() {
+        let mut vm = VirtualMachine::new(false);
+        let base_address = vm.add_memory_segment();
+
+        let m = MyType { a: Felt252::ONE, b: Felt252::TWO, c: Felt252::THREE };
+        m.to_memory(&mut vm, base_address).unwrap();
+
+        let values = vm.get_integer_range(base_address, 3).unwrap();
+        assert_eq!(values[0], Cow::Borrowed(&m.a));
+        assert_eq!(values[1], Cow::Borrowed(&m.b));
+        assert_eq!(values[2], Cow::Borrowed(&m.c));
+    }
+
+    #[test]
+    fn read_cairo_type() {
+        let mut vm = VirtualMachine::new(false);
+
+        // Check that reading from a non-existing segment fails
+        assert!(MyType::from_memory(&mut vm, Relocatable::from((0, 0))).is_err());
+
+        // Check that reading an existing segment without data fails
+        let base_address = vm.add_memory_segment();
+        assert!(MyType::from_memory(&mut vm, base_address).is_err());
+
+        // Write the data and read it
+        vm.insert_value(base_address, Felt252::ONE).unwrap();
+        vm.insert_value(&base_address + 1, Felt252::TWO).unwrap();
+        vm.insert_value(&base_address + 2, Felt252::THREE).unwrap();
+
+        let m = MyType::from_memory(&vm, base_address).unwrap();
+        assert_eq!(m.a, Felt252::ONE);
+        assert_eq!(m.b, Felt252::TWO);
+        assert_eq!(m.c, Felt252::THREE);
+    }
+
+    #[test]
+    fn n_fields() {
+        assert_eq!(MyType::n_fields(), 3);
+    }
+
+    #[test]
+    fn field_offsets() {
+        assert_eq!(MyType::a_offset(), 0);
+        assert_eq!(MyType::b_offset(), 1);
+        assert_eq!(MyType::c_offset(), 2);
+    }
+}

--- a/src/cairo_types/trie.rs
+++ b/src/cairo_types/trie.rs
@@ -1,0 +1,14 @@
+use cairo_type_derive::CairoType;
+use cairo_vm::types::relocatable::Relocatable;
+use cairo_vm::vm::errors::memory_errors::MemoryError;
+use cairo_vm::vm::vm_core::VirtualMachine;
+use cairo_vm::Felt252;
+
+use crate::cairo_types::traits::CairoType;
+
+#[derive(CairoType)]
+pub struct NodeEdge {
+    pub length: Felt252,
+    pub path: Felt252,
+    pub bottom: Felt252,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod cairo_types;
 pub mod config;
 pub mod error;
 pub mod execution;


### PR DESCRIPTION
Problem: Cairo structs are accessed in some hints. The Python VM has abstractions to access fields by name that the Rust VM cannot implement. This leads to accessing these structs by hardcoding the offset of each field.

Solution: The new `CairoType` trait allows to read/write an entire struct in one go. The derive implementation reads/writes fields one by one according to their place in the struct definition. For cases where reading/writing the whole struct is not appropriate, the new `FieldOffsetGetters` macro implements a `get_<field>_offset()` method for each field of the struct to avoid hardcoding values.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
