### PR TITLE
Add old block info hint

### DIFF
--- a/src/hints/block_context.rs
+++ b/src/hints/block_context.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use blockifier::block_context::BlockContext;
 use cairo_vm::hint_processor::builtin_hint_processor::dict_manager::Dictionary;
 use cairo_vm::hint_processor::builtin_hint_processor::hint_utils::{
-    get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name, insert_value_into_ap
+    get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name, insert_value_into_ap,
 };
 use cairo_vm::hint_processor::hint_processor_definition::{HintExtension, HintProcessor, HintReference};
 use cairo_vm::serde::deserialize_program::{ApTracking, HintParams, ReferenceManager};
@@ -315,12 +315,8 @@ pub fn get_old_block_number_and_hash(
         .ok_or(HintError::CustomHint("ExecutionHelper should have prev_block_context".to_owned().into_boxed_str()))?
         .block_number;
 
-    let ids_old_block_number = get_integer_from_var_name(
-        vars::ids::OLD_BLOCK_NUMBER,
-        vm,
-        ids_data,
-        ap_tracking
-    )?.into_owned();
+    let ids_old_block_number =
+        get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?.into_owned();
 
     assert_eq!(
         Felt252::from(old_block_number.0),
@@ -334,4 +330,3 @@ pub fn get_old_block_number_and_hash(
 
     Ok(())
 }
-

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -39,7 +39,7 @@ type HintImpl = fn(
     &HashMap<String, Felt252>,
 ) -> Result<(), HintError>;
 
-static HINTS: [(&str, HintImpl); 59] = [
+static HINTS: [(&str, HintImpl); 60] = [
     // (BREAKPOINT, breakpoint),
     (STARKNET_OS_INPUT, starknet_os_input),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -60,6 +60,7 @@ static HINTS: [(&str, HintImpl); 59] = [
     (block_context::FEE_TOKEN_ADDRESS, block_context::fee_token_address),
     (block_context::DEPRECATED_FEE_TOKEN_ADDRESS, block_context::deprecated_fee_token_address),
     (block_context::GET_BLOCK_MAPPING, block_context::get_block_mapping),
+    (block_context::GET_OLD_BLOCK_NUMBER_AND_HASH, block_context::get_old_block_number_and_hash),
     (execution::ENTER_SYSCALL_SCOPES, execution::enter_syscall_scopes),
     (execution::GET_STATE_ENTRY, execution::get_state_entry),
     (execution::CHECK_IS_DEPRECATED, execution::check_is_deprecated),

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -279,19 +279,14 @@ pub(crate) mod tests {
             &mut exec_scopes,
             &ids_data,
             &ap_tracking,
-            &Default::default()
-        ).expect("get_old_block_number_and_hash");
-
-        let ids_old_block_hash = get_integer_from_var_name(
-            vars::ids::OLD_BLOCK_HASH,
-            &vm,
-            &ids_data,
-            &ap_tracking
+            &Default::default(),
         )
-        .expect("fn didn't insert old_block_hash")
-        .into_owned();
+        .expect("get_old_block_number_and_hash");
+
+        let ids_old_block_hash = get_integer_from_var_name(vars::ids::OLD_BLOCK_HASH, &vm, &ids_data, &ap_tracking)
+            .expect("fn didn't insert old_block_hash")
+            .into_owned();
 
         assert_eq!(ids_old_block_hash, 42.into());
-
     }
 }

--- a/src/hints/vars.rs
+++ b/src/hints/vars.rs
@@ -14,6 +14,8 @@ pub mod ids {
     pub const IS_ON_CURVE: &str = "is_on_curve";
     pub const MERKLE_HEIGHT: &str = "MERKLE_HEIGHT";
     pub const NODE: &str = "node";
+    pub const OLD_BLOCK_HASH: &str = "old_block_hash";
+    pub const OLD_BLOCK_NUMBER: &str = "old_block_number";
     pub const OS_CONTEXT: &str = "os_context";
     pub const SECP_P: &str = "SECP_P";
     pub const SYSCALL_PTR: &str = "syscall_ptr";


### PR DESCRIPTION
Adds old block info hint. This is used shortly before txn execution in the OS
