### PR TITLE
Create storage for final storage if needed

### DIFF
--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -1498,8 +1498,8 @@ pub fn write_syscall_result(
     );
 
     // ids.prev_value = storage.read(key=ids.request.key)
-    let read_result = execution_helper.read_storage_for_address(contract_address, storage_write_address);
-    let prev_value = read_result.unwrap_or_default();
+    let prev_value =
+        execution_helper.read_storage_for_address(contract_address, storage_write_address).unwrap_or_default();
     insert_value_from_var_name(vars::ids::PREV_VALUE, prev_value, vm, ids_data, ap_tracking)?;
 
     // storage.write(key=ids.request.key, value=ids.request.value)

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -1492,7 +1492,10 @@ pub fn write_syscall_result(
     let storage_write_address = *vm.get_integer((request + NewStorageWriteRequest::key_offset())?)?;
     let storage_write_value = vm.get_integer((request + NewStorageWriteRequest::value_offset())?)?.into_owned();
 
-    println!("write_syscall_result hint wants to write {} to {}/{}", storage_write_value, contract_address, storage_write_address);
+    println!(
+        "write_syscall_result hint wants to write {} to {}/{}",
+        storage_write_value, contract_address, storage_write_address
+    );
 
     // ids.prev_value = storage.read(key=ids.request.key)
     let read_result = execution_helper.read_storage_for_address(contract_address, storage_write_address);

--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -116,7 +116,10 @@ impl CommitmentInfo {
         let actual_updated_root = Felt252::from_bytes_be_slice(&actual_updated_tree.root);
 
         if actual_updated_root != expected_updated_root {
-            println!("actual_updated_root != expected_updated_root ({} != {})", actual_updated_root, expected_updated_root);
+            println!(
+                "actual_updated_root != expected_updated_root ({} != {})",
+                actual_updated_root, expected_updated_root
+            );
             return Err(CommitmentInfoError::UpdatedRootMismatch);
         }
 

--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -116,6 +116,7 @@ impl CommitmentInfo {
         let actual_updated_root = Felt252::from_bytes_be_slice(&actual_updated_tree.root);
 
         if actual_updated_root != expected_updated_root {
+            println!("actual_updated_root != expected_updated_root ({} != {})", actual_updated_root, expected_updated_root);
             return Err(CommitmentInfoError::UpdatedRootMismatch);
         }
 

--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -129,7 +129,8 @@ pub fn build_starknet_storage(blockifier_state: &mut CachedState<DictStateReader
     let initial_contract_storage_map = get_contract_storage_map(&blockifier_state.state.storage_view);
     let final_contract_storage_map = build_final_storage_map(blockifier_state);
 
-    let all_contracts = initial_contract_storage_map.keys().chain(final_contract_storage_map.keys()).collect::<HashSet<&Felt252>>();
+    let all_contracts =
+        initial_contract_storage_map.keys().chain(final_contract_storage_map.keys()).collect::<HashSet<&Felt252>>();
 
     let mut storage_by_address = ContractStorageMap::new();
 
@@ -139,8 +140,8 @@ pub fn build_starknet_storage(blockifier_state: &mut CachedState<DictStateReader
     for contract_address in all_contracts {
         println!("Creating initial state for contract {}", contract_address);
         let initial_contract_storage = initial_contract_storage_map.get(contract_address).unwrap_or(&empty_state);
-        let final_contract_storage = final_contract_storage_map.get(&contract_address)
-            .expect("any contract should appear in final storage");
+        let final_contract_storage =
+            final_contract_storage_map.get(&contract_address).expect("any contract should appear in final storage");
 
         execute_coroutine_threadsafe(async {
             let initial_tree =

--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -141,11 +141,11 @@ pub fn build_starknet_storage(blockifier_state: &mut CachedState<DictStateReader
         println!("Creating initial state for contract {}", contract_address);
         let initial_contract_storage = initial_contract_storage_map.get(contract_address).unwrap_or(&empty_state);
         let final_contract_storage =
-            final_contract_storage_map.get(&contract_address).expect("any contract should appear in final storage");
+            final_contract_storage_map.get(contract_address).expect("any contract should appear in final storage");
 
         execute_coroutine_threadsafe(async {
             let initial_tree =
-                build_patricia_tree_from_contract_storage(&mut ffc, &initial_contract_storage).await.unwrap();
+                build_patricia_tree_from_contract_storage(&mut ffc, initial_contract_storage).await.unwrap();
             let updated_tree =
                 build_patricia_tree_from_contract_storage(&mut ffc, final_contract_storage).await.unwrap();
 

--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use blockifier::state::cached_state::{CachedState, StorageEntry};
 use blockifier::state::state_api::State;
@@ -129,11 +129,18 @@ pub fn build_starknet_storage(blockifier_state: &mut CachedState<DictStateReader
     let initial_contract_storage_map = get_contract_storage_map(&blockifier_state.state.storage_view);
     let final_contract_storage_map = build_final_storage_map(blockifier_state);
 
+    let all_contracts = initial_contract_storage_map.keys().chain(final_contract_storage_map.keys()).collect::<HashSet<&Felt252>>();
+
     let mut storage_by_address = ContractStorageMap::new();
 
+    let empty_state = Default::default();
+
     let mut ffc = FactFetchingContext::new(DictStorage::default());
-    for (contract_address, initial_contract_storage) in initial_contract_storage_map {
-        let final_contract_storage = final_contract_storage_map.get(&contract_address).unwrap();
+    for contract_address in all_contracts {
+        println!("Creating initial state for contract {}", contract_address);
+        let initial_contract_storage = initial_contract_storage_map.get(contract_address).unwrap_or(&empty_state);
+        let final_contract_storage = final_contract_storage_map.get(&contract_address)
+            .expect("any contract should appear in final storage");
 
         execute_coroutine_threadsafe(async {
             let initial_tree =
@@ -143,7 +150,7 @@ pub fn build_starknet_storage(blockifier_state: &mut CachedState<DictStateReader
 
             let contract_storage =
                 OsSingleStarknetStorage::new(initial_tree, updated_tree, &[], ffc.clone()).await.unwrap();
-            storage_by_address.insert(contract_address, contract_storage);
+            storage_by_address.insert(*contract_address, contract_storage);
         });
     }
 

--- a/tests/os.rs
+++ b/tests/os.rs
@@ -129,5 +129,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
     let r = execute_txs_and_run_os(state, block_context, txs);
 
     // temporarily expect test to break somewhere in the state_update function
-    assert!(&format!("{:?}", r).contains(r#"CustomHint("Storage not found for contract 3221227264")"#));
+    // assert!(&format!("{:?}", r).contains(r#"CustomHint("Storage not found for contract 3221227264")"#));
 }

--- a/tests/os.rs
+++ b/tests/os.rs
@@ -129,5 +129,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
     let r = execute_txs_and_run_os(state, block_context, txs);
 
     // temporarily expect test to break somewhere in the state_update function
-    assert!(&format!("{:?}", r).contains(r#"CustomHint("Storage not found for contract 3221227264")"#));
+    assert!(&format!("{:?}", r).contains(r#"AssertionFailed("Tree height does not match Merkle height")))"#));
 }

--- a/tests/os.rs
+++ b/tests/os.rs
@@ -129,5 +129,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
     let r = execute_txs_and_run_os(state, block_context, txs);
 
     // temporarily expect test to break somewhere in the state_update function
-    // assert!(&format!("{:?}", r).contains(r#"CustomHint("Storage not found for contract 3221227264")"#));
+    assert!(&format!("{:?}", r).contains(r#"CustomHint("Storage not found for contract 3221227264")"#));
 }


### PR DESCRIPTION
Previously we created `OsSingleStarknetStorage` for the initial state from Blockifier, but this caused problems when this didn't include contracts that were going to be written to for the first time in a block. So we now use contracts from the union of {initial, final} state.

This also changes the write syscall so that it tolerates missing `prev_value`. I'm not sure what the correct behavior is here, but returning default in this case seems to work.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
