### PR TITLE
Use set_storage_at instead of storage_view

### DIFF
--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -25,7 +25,7 @@ use crate::starknet::starknet_storage::StorageLeaf;
 use crate::starkware_utils::commitment_tree::base_types::{DescentMap, DescentPath, DescentStart, Height, NodePath};
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_guess_descents::patricia_guess_descents;
 use crate::starkware_utils::commitment_tree::update_tree::{
-    build_update_tree, decode_node, DecodeNodeCase, DecodedNode, TreeUpdate,
+    build_update_tree, decode_node, DecodeNodeCase, DecodedNode, TreeUpdate, UpdateTree,
 };
 
 pub const SET_SIBLINGS: &str = "memory[ids.siblings], ids.word = descend";
@@ -329,7 +329,7 @@ pub fn build_descent_map(
 
     let preimage: &Preimage = exec_scopes.get_ref(vars::scopes::PREIMAGE)?;
 
-    let node = build_update_tree(height, modifications);
+    let node: UpdateTree<StorageLeaf> = build_update_tree(height, modifications);
     let descent_map = patricia_guess_descents::<StorageLeaf>(height, node.clone(), preimage, prev_root, new_root)?;
 
     exec_scopes.insert_value(vars::scopes::NODE, node.clone());

--- a/src/hints/state.rs
+++ b/src/hints/state.rs
@@ -22,7 +22,7 @@ use crate::hints::types::{skip_verification_if_configured, Preimage};
 use crate::hints::vars;
 use crate::io::input::StarknetOsInput;
 use crate::starknet::starknet_storage::{execute_coroutine_threadsafe, CommitmentInfo, StorageLeaf};
-use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, TreeUpdate};
+use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, TreeUpdate, UpdateTree};
 use crate::utils::get_constant;
 
 fn assert_tree_height_eq_merkle_height(tree_height: Felt252, merkle_height: Felt252) -> Result<(), HintError> {
@@ -278,7 +278,8 @@ pub fn decode_node_hint(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let node: TreeUpdate<StorageLeaf> = exec_scopes.get(vars::scopes::NODE)?;
+    let node: UpdateTree<StorageLeaf> = exec_scopes.get(vars::scopes::NODE)?;
+    let node = node.ok_or(HintError::CustomHint("Node should not be None".to_string().into_boxed_str()))?;
     let DecodedNode { left_child, right_child, case } = decode_node(&node)?;
     exec_scopes.insert_value(vars::scopes::LEFT_CHILD, left_child.clone());
     exec_scopes.insert_value(vars::scopes::RIGHT_CHILD, right_child.clone());

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use blockifier::block_context::BlockContext;
 use blockifier::execution::contract_class::ContractClass::{V0, V1};
 use blockifier::state::cached_state::CachedState;
-use blockifier::state::state_api::StateReader;
+use blockifier::state::state_api::{State as _, StateReader};
 use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::contracts::FeatureContract::{
     AccountWithLongValidate, AccountWithoutValidations, Empty, FaultyAccount, SecurityTests, TestContract, ERC20,
@@ -156,9 +156,7 @@ pub fn test_state(
 
     let block_hash_contract_address = ContractAddress::try_from(stark_felt!(BLOCK_HASH_CONTRACT_ADDRESS)).unwrap();
 
-    let storage_view = &mut state.state.storage_view;
-
-    storage_view.insert((block_hash_contract_address, block_number), block_hash);
+    state.set_storage_at(block_hash_contract_address, block_number, block_hash).unwrap();
 
     state
 }


### PR DESCRIPTION
I think this fixes the tree traversal issue with the block_number storage.

Note that now we traverse into `traverse_empty()` instead of `traverse_edge()` for this node.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
