### PR TITLE
Global state setup continuation

### DIFF
--- a/src/starknet/business_logic/fact_state/contract_class_objects.rs
+++ b/src/starknet/business_logic/fact_state/contract_class_objects.rs
@@ -10,7 +10,7 @@ use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionT
 /// Represents a leaf in the Starknet contract class tree.
 #[derive(Deserialize, Clone, Debug, Serialize, PartialEq)]
 pub struct ContractClassLeaf {
-    compiled_class_hash: Felt252,
+    pub compiled_class_hash: Felt252,
 }
 
 impl ContractClassLeaf {

--- a/src/starknet/business_logic/fact_state/state.rs
+++ b/src/starknet/business_logic/fact_state/state.rs
@@ -8,7 +8,7 @@ use blockifier::test_utils::dict_state_reader::DictStateReader;
 use cairo_vm::types::errors::math_errors::MathError;
 use cairo_vm::Felt252;
 use num_bigint::BigUint;
-use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce, PatriciaKey};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 
@@ -325,19 +325,14 @@ impl SharedState {
             block_info,
         })
     }
-}
 
-impl StateReader for SharedState {
-    /// Returns the storage value under the given key in the given contract instance (represented by
-    /// its address).
-    /// Default: 0 for an uninitialized contract address.
-    fn get_storage_at(
-        &mut self,
+    /// helper to get contract_state
+    /// TODO: move? make async? (it helps to not be async...)
+    pub fn get_contract_state(
+        &self,
         contract_address: ContractAddress,
-        key: StorageKey,
-    ) -> StateResult<StarkFelt> {
+    ) -> StateResult<ContractState> {
         let contract_address: TreeIndex = felt_api2vm(*contract_address.0.key()).to_biguint();
-        let storage_key: TreeIndex = felt_api2vm(*key.0.key()).to_biguint();
 
         // TODO: FFC makes no sense here
         let mut ffc = FactFetchingContext::<DictStorage, PedersenHash>::new(Default::default());
@@ -354,6 +349,27 @@ impl StateReader for SharedState {
             StateResult::Ok(contract_state)
         })?;
 
+        Ok(contract_state)
+    }
+}
+
+impl StateReader for SharedState {
+
+
+    /// Returns the storage value under the given key in the given contract instance (represented by
+    /// its address).
+    /// Default: 0 for an uninitialized contract address.
+    fn get_storage_at(
+        &mut self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+    ) -> StateResult<StarkFelt> {
+        let storage_key: TreeIndex = felt_api2vm(*key.0.key()).to_biguint();
+
+        let contract_state = self.get_contract_state(contract_address)?;
+
+        // TODO: FFC makes no sense here
+        let mut ffc = FactFetchingContext::<DictStorage, PedersenHash>::new(Default::default());
         let state = execute_coroutine_threadsafe(async {
             let storage_items: HashMap<TreeIndex, StorageLeaf> = contract_state.storage_commitment_tree
                 .get_leaves(&mut ffc, &[storage_key.clone()], &mut None)
@@ -373,13 +389,15 @@ impl StateReader for SharedState {
     /// Returns the nonce of the given contract instance.
     /// Default: 0 for an uninitialized contract address.
     fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        unimplemented!();
+        let contract_state = self.get_contract_state(contract_address)?;
+        Ok(Nonce(felt_vm2api(contract_state.nonce)))
     }
 
     /// Returns the class hash of the contract class at the given contract instance.
     /// Default: 0 (uninitialized class hash) for an uninitialized contract address.
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        unimplemented!();
+        let contract_state = self.get_contract_state(contract_address)?;
+        Ok(ClassHash(felt_vm2api(contract_state.nonce)))
     }
 
     /// Returns the contract class of the given class hash.


### PR DESCRIPTION
Continues work on https://github.com/keep-starknet-strange/snos/pull/193

### TODO
 - [ ] Undo changes to `cairo-lang` submodule